### PR TITLE
ci(release): centralize semantic-release config and fix workflows

### DIFF
--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -4,25 +4,47 @@ on:
   push:
     branches: [develop]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   prerelease-frontend:
     name: Pre-release Frontend
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-      - name: Install deps
+          # Cachea tanto root como frontend
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+
+      # Identidad de git para commits de @semantic-release/git (si lo usás en frontend)
+      - name: Configure git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # 1) Instalar semantic-release + plugins en la RAÍZ (para resolverlos "hacia arriba")
+      - name: Install semantic-release plugins (root)
+        working-directory: .
         run: npm ci
+
+      # 2) Instalar dependencias del frontend (si las tiene)
+      - name: Install deps (frontend)
+        working-directory: frontend
+        run: npm ci
+
+      # 3) Correr semantic-release desde el frontend usando plugins instalados en raíz
       - name: semantic-release (frontend)
+        working-directory: frontend
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -44,13 +66,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Instala semantic-release y plugins en la RAÍZ (no hay package.json en los micros Java)
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: package-lock.json
+
+      - name: Configure git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # Instala semantic-release y plugins en la RAÍZ (los micros Java no tienen package.json)
       - name: Install semantic-release plugins (root)
+        working-directory: .
         run: npm ci
 
       # Detecta si cambió la carpeta del micro desde su último tag propio
@@ -62,16 +91,12 @@ jobs:
           LAST_TAG=$(git tag --list '${{ matrix.svc.tag }}' --sort=-v:refname | head -n1 || true)
           echo "LAST_TAG=$LAST_TAG"
           if [ -z "$LAST_TAG" ]; then
-            echo "No hay tags previos para ${{ matrix.svc.name }} -> marcar changed=true"
             echo "changed=true" >> $GITHUB_OUTPUT
             exit 0
           fi
-
           if git diff --name-only "$LAST_TAG"...HEAD | grep -q '^${{ matrix.svc.path }}/'; then
-            echo "Hay cambios en ${{ matrix.svc.path }} desde $LAST_TAG"
             echo "changed=true" >> $GITHUB_OUTPUT
           else
-            echo "Sin cambios en ${{ matrix.svc.path }} desde $LAST_TAG"
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -1,26 +1,49 @@
-# .github/workflows/release-main.yml
 name: Release - main
+
 on:
   push:
     branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   release-frontend:
     name: Release Frontend
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-      - run: npm ci
+          # Cachea lockfiles de raíz y de frontend
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+
+      # Identidad para commits de @semantic-release/git (si lo usás en frontend)
+      - name: Configure git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # 1) Instala semantic-release + plugins en la RAÍZ (resueltos "hacia arriba")
+      - name: Install semantic-release plugins (root)
+        working-directory: .
+        run: npm ci
+
+      # 2) Instala dependencias del frontend (si tiene otras deps)
+      - name: Install deps (frontend)
+        working-directory: frontend
+        run: npm ci
+
+      # 3) Ejecuta semantic-release desde frontend usando plugins instalados en raíz
       - name: semantic-release (frontend)
+        working-directory: frontend
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -41,13 +64,20 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 
-      # Plugins de semantic-release instalados en la RAÍZ (no hay package.json en micros Java)
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: package-lock.json
+
+      - name: Configure git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # Instala semantic-release y plugins en la RAÍZ (los micros Java no tienen package.json)
       - name: Install semantic-release plugins (root)
+        working-directory: .
         run: npm ci
 
       - name: semantic-release (${{ matrix.svc.name }})


### PR DESCRIPTION
- Updated release-main workflow to install plugins from root
- Added git user config so semantic-release can push tags/commits
- Adjusted cache paths (root + frontend lockfiles)
- Ensured release.config files use CommonJS
- Synced tagFormat with docker-release tagprefix