### PR TITLE
ci(workflows): fix semantic-release races on develop and main

### DIFF
--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -31,6 +31,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch --prune
+          git checkout ${{ github.ref_name }}   # normalmente 'develop'
+          git pull --ff-only origin ${{ github.ref_name }}
+
 
       # 1) Instalar semantic-release + plugins en la RAÍZ (para resolverlos "hacia arriba")
       - name: Install semantic-release plugins (root)
@@ -61,6 +65,7 @@ jobs:
           - { name: ticket-service, path: "backend/ticket-service",      tag: "ticket-service-v*" }
           - { name: payment-service, path: "backend/payment-service",    tag: "payment-service-v*" }
           - { name: notification-service, path: "backend/notification-service", tag: "notification-service-v*" }
+      max-parallel: 1   
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -74,6 +74,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch --prune
+          git checkout ${{ github.ref_name }}   # normalmente 'develop'
+          git pull --ff-only origin ${{ github.ref_name }}
 
       # Instala semantic-release y plugins en la RAÍZ (los micros Java no tienen package.json)
       - name: Install semantic-release plugins (root)
@@ -100,6 +103,7 @@ jobs:
           - { name: ticket,   path: "backend/ticket-service", image: "ticketera-ticket-service", tagprefix: "ticket-service-v" }
           - { name: payment,  path: "backend/payment-service", image: "ticketera-payment-service", tagprefix: "payment-service-v" }
           - { name: notif,    path: "backend/notification-service", image: "ticketera-notification-service", tagprefix: "notification-service-v" }
+      max-parallel: 1   
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }


### PR DESCRIPTION
- Run `git pull --ff-only` before semantic-release to avoid "local branch is behind"
- Serialize matrix (max-parallel: 1) to prevent concurrent pushes to the same branch
- Add concurrency group per service and disable cancel-in-progress to avoid self-cancellation
- Set git user identity so @semantic-release/git can commit changelogs/tags reliably
- Keep [skip ci] on SR commit messages to avoid recursive workflow runs
- Apply same fixes to both release-develop and release-main workflows
- Minor cache/path cleanups in release workflows