### PR TITLE
ci(docker): fix GHCR pushes in prerelease (develop) and release (main…

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,3 +1,4 @@
+# .github/workflows/ci-pr.yml
 name: CI - PR
 
 on:

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 jobs:
   prerelease-frontend:
@@ -21,32 +22,26 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          # Cachea tanto root como frontend
           cache-dependency-path: |
             package-lock.json
             frontend/package-lock.json
 
-      # Identidad de git para commits de @semantic-release/git (si lo usás en frontend)
       - name: Configure git user
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch --prune
-          git checkout ${{ github.ref_name }}   # normalmente 'develop'
+          git checkout ${{ github.ref_name }}
           git pull --ff-only origin ${{ github.ref_name }}
 
-
-      # 1) Instalar semantic-release + plugins en la RAÍZ (para resolverlos "hacia arriba")
       - name: Install semantic-release plugins (root)
         working-directory: .
         run: npm ci
 
-      # 2) Instalar dependencias del frontend (si las tiene)
       - name: Install deps (frontend)
         working-directory: frontend
         run: npm ci
 
-      # 3) Correr semantic-release desde el frontend usando plugins instalados en raíz
       - name: semantic-release (frontend)
         working-directory: frontend
         run: npx semantic-release
@@ -59,13 +54,13 @@ jobs:
     strategy:
       matrix:
         svc:
-          - { name: gateway,      path: "backend/gateway",               tag: "gateway-v*" }
-          - { name: auth-service, path: "backend/auth-service",          tag: "auth-service-v*" }
-          - { name: event-service, path: "backend/event-service",        tag: "event-service-v*" }
-          - { name: ticket-service, path: "backend/ticket-service",      tag: "ticket-service-v*" }
-          - { name: payment-service, path: "backend/payment-service",    tag: "payment-service-v*" }
+          - { name: gateway,      path: "backend/gateway",                  tag: "gateway-v*" }
+          - { name: auth-service, path: "backend/auth-service",             tag: "auth-service-v*" }
+          - { name: event-service, path: "backend/event-service",           tag: "event-service-v*" }
+          - { name: ticket-service, path: "backend/ticket-service",         tag: "ticket-service-v*" }
+          - { name: payment-service, path: "backend/payment-service",       tag: "payment-service-v*" }
           - { name: notification-service, path: "backend/notification-service", tag: "notification-service-v*" }
-      max-parallel: 1   
+      max-parallel: 1
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,12 +77,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      # Instala semantic-release y plugins en la RAÍZ (los micros Java no tienen package.json)
       - name: Install semantic-release plugins (root)
         working-directory: .
         run: npm ci
 
-      # Detecta si cambió la carpeta del micro desde su último tag propio
       - name: Detect changes (${{ matrix.svc.name }})
         id: changed
         shell: bash
@@ -131,21 +124,20 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
+      - name: Compute vars (lowercase owner + short sha)
+        id: vars
+        shell: bash
+        run: |
+          echo "owner_lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+          echo "sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "tag1=${GITHUB_REF_NAME}-next-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
       - name: Login GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ steps.vars.outputs.owner_lc }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute tags
-        id: vars
-        shell: bash
-        run: |
-          SHA=${GITHUB_SHA::7}
-          echo "sha=${SHA}" >> $GITHUB_OUTPUT
-          # canal 'next' para develop
-          echo "tag1=${{ github.ref_name }}-next-${SHA}" >> $GITHUB_OUTPUT
 
       - name: Build & Push ${{ matrix.svc.name }}
         uses: docker/build-push-action@v6
@@ -156,4 +148,4 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
-            ghcr.io/${{ github.repository_owner }}/${{ matrix.svc.image }}:${{ steps.vars.outputs.tag1 }}
+            ghcr.io/${{ steps.vars.outputs.owner_lc }}/${{ matrix.svc.image }}:${{ steps.vars.outputs.tag1 }}

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 jobs:
   release-frontend:
@@ -75,7 +76,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch --prune
-          git checkout ${{ github.ref_name }}   # normalmente 'develop'
+          git checkout ${{ github.ref_name }}   # normalmente 'main'
           git pull --ff-only origin ${{ github.ref_name }}
 
       # Instala semantic-release y plugins en la RAÍZ (los micros Java no tienen package.json)
@@ -103,18 +104,24 @@ jobs:
           - { name: ticket,   path: "backend/ticket-service", image: "ticketera-ticket-service", tagprefix: "ticket-service-v" }
           - { name: payment,  path: "backend/payment-service", image: "ticketera-payment-service", tagprefix: "payment-service-v" }
           - { name: notif,    path: "backend/notification-service", image: "ticketera-notification-service", tagprefix: "notification-service-v" }
-      max-parallel: 1   
+      max-parallel: 1   # evita empujes concurrentes a GHCR
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 
       - uses: docker/setup-buildx-action@v3
 
+      - name: Compute vars (lowercase owner)
+        id: vars
+        shell: bash
+        run: |
+          echo "owner_lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+
       - name: Login GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ steps.vars.outputs.owner_lc }}   # owner en lowercase
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read version tag for this module
@@ -143,5 +150,5 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
-            ghcr.io/${{ github.repository_owner }}/${{ matrix.svc.image }}:v${{ steps.ver.outputs.version }}
-            ghcr.io/${{ github.repository_owner }}/${{ matrix.svc.image }}:latest
+            ghcr.io/${{ steps.vars.outputs.owner_lc }}/${{ matrix.svc.image }}:v${{ steps.ver.outputs.version }}
+            ghcr.io/${{ steps.vars.outputs.owner_lc }}/${{ matrix.svc.image }}:latest


### PR DESCRIPTION
…) workflows

- Add `packages: write` permission so jobs can publish to GHCR
- Compute lowercase repository owner via bash (`${GITHUB_REPOSITORY_OWNER,,}`)
- Use lowercase owner for docker/login and image tags in both workflows
- Keep prerelease tag format on develop: `<branch>-next-<shortsha>`
- Keep release tag format on main: `v<version>` and `latest`
- Set `max-parallel: 1` for docker-release to avoid concurrent GHCR pushes