### PR TITLE
feat(db): full schema redesign with timestamps and soft delete

### DIFF
--- a/backend/auth-service/src/main/resources/db/migration/V1__init.sql
+++ b/backend/auth-service/src/main/resources/db/migration/V1__init.sql
@@ -1,4 +1,6 @@
-CREATE TABLE users (
+CREATE SCHEMA IF NOT EXISTS auth;
+
+CREATE TABLE auth.users (
   id            bigserial PRIMARY KEY,
   email         text NOT NULL UNIQUE,
   password_hash text NOT NULL,
@@ -6,22 +8,58 @@ CREATE TABLE users (
   last_name     text,
   is_active     boolean NOT NULL DEFAULT true,
   created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  deleted_at    timestamptz,
   last_login_at timestamptz
 );
 
-CREATE TABLE roles (
+CREATE TABLE auth.roles (
   id    bigserial PRIMARY KEY,
-  code  text NOT NULL UNIQUE,  -- 'owner','admin','manager','seller','checker','viewer'
+  code  text NOT NULL UNIQUE,
   name  text NOT NULL,
-  description text
+  description text,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  deleted_at    timestamptz
 );
 
-CREATE TABLE api_keys (
-  id             bigserial PRIMARY KEY,
-  organizer_id   bigint NOT NULL,
-  name           text NOT NULL,
-  token_hash     text NOT NULL,
-  scopes         text[] NOT NULL DEFAULT '{}',
-  created_at     timestamptz NOT NULL DEFAULT now(),
-  last_used_at   timestamptz
+CREATE TABLE auth.organizers (
+  id            bigserial PRIMARY KEY,
+  name          text NOT NULL,
+  slug          text NOT NULL UNIQUE,
+  contact_email text,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  deleted_at    timestamptz
+);
+
+CREATE TABLE auth.categories (
+  id          bigserial PRIMARY KEY,
+  name        text NOT NULL UNIQUE,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  deleted_at  timestamptz
+);
+
+CREATE TABLE auth.organizer_memberships (
+  id            bigserial PRIMARY KEY,
+  organizer_id  bigint NOT NULL REFERENCES auth.organizers(id) ON DELETE CASCADE,
+  user_id       bigint NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  role_id       bigint NOT NULL REFERENCES auth.roles(id),
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  deleted_at    timestamptz,
+  UNIQUE (organizer_id, user_id)
+);
+
+CREATE TABLE auth.api_keys (
+  id            bigserial PRIMARY KEY,
+  organizer_id  bigint NOT NULL REFERENCES auth.organizers(id) ON DELETE CASCADE,
+  name          text NOT NULL,
+  token_hash    text NOT NULL,
+  scopes        text[] NOT NULL DEFAULT '{}',
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  deleted_at    timestamptz,
+  last_used_at  timestamptz
 );

--- a/backend/event-service/src/main/resources/db/migration/V1__init.sql
+++ b/backend/event-service/src/main/resources/db/migration/V1__init.sql
@@ -1,54 +1,160 @@
-CREATE TABLE organizers (
-  id               bigserial PRIMARY KEY,
-  name             text NOT NULL,
-  slug             text NOT NULL UNIQUE,
-  contact_email    text,
-  created_at       timestamptz NOT NULL DEFAULT now()
+CREATE SCHEMA IF NOT EXISTS events;
+
+CREATE TABLE events.events (
+  id            bigserial PRIMARY KEY,
+  organizer_id  bigint NOT NULL REFERENCES auth.organizers(id),
+  title         text NOT NULL,
+  slug          text NOT NULL,
+  description   text,
+  category_id   bigint REFERENCES auth.categories(id),
+  cover_url     text,
+  status        text NOT NULL DEFAULT 'draft',
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  deleted_at    timestamptz,
+  UNIQUE (organizer_id, slug),
+  CONSTRAINT ck_events_status CHECK (status IN ('draft','published','archived'))
 );
 
-CREATE TABLE categories (
-  id               bigserial PRIMARY KEY,
-  name             text NOT NULL UNIQUE
+CREATE TABLE events.event_grants (
+  id            bigserial PRIMARY KEY,
+  event_id      bigint NOT NULL REFERENCES events.events(id) ON DELETE CASCADE,
+  membership_id bigint NOT NULL REFERENCES auth.organizer_memberships(id) ON DELETE CASCADE,
+  can_manage    boolean NOT NULL DEFAULT false,
+  can_sell      boolean NOT NULL DEFAULT false,
+  can_check     boolean NOT NULL DEFAULT false,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  deleted_at    timestamptz,
+  UNIQUE (event_id, membership_id)
 );
 
-CREATE TABLE events (
-  id               bigserial PRIMARY KEY,
-  organizer_id     bigint NOT NULL REFERENCES organizers(id),
-  title            text NOT NULL,
-  slug             text NOT NULL,
-  description      text,
-  category_id      bigint REFERENCES categories(id),
-  cover_url        text,
-  status           text NOT NULL DEFAULT 'draft',
-  created_at       timestamptz NOT NULL DEFAULT now(),
-  UNIQUE (organizer_id, slug)
+CREATE TABLE events.event_media (
+  id        bigserial PRIMARY KEY,
+  event_id  bigint NOT NULL REFERENCES events.events(id) ON DELETE CASCADE,
+  url       text NOT NULL,
+  alt       text,
+  position  int NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz
 );
 
-ALTER TABLE events
-  ADD CONSTRAINT ck_events_status CHECK (status IN ('draft','published','archived'));
-
-CREATE TABLE event_media (
-  id       bigserial PRIMARY KEY,
-  event_id bigint NOT NULL REFERENCES events(id) ON DELETE CASCADE,
-  url      text NOT NULL,
-  alt      text,
-  position int NOT NULL DEFAULT 0
+-- VENUE base (plantilla)
+CREATE TABLE events.venues (
+  id            bigserial PRIMARY KEY,
+  organizer_id  bigint REFERENCES auth.organizers(id),
+  name          text NOT NULL,
+  description   text,
+  address_line  text,
+  city          text,
+  state         text,
+  country       text,
+  lat           numeric(10,6),
+  lng           numeric(10,6),
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  deleted_at    timestamptz
 );
 
-CREATE TABLE venues (
-  id           bigserial PRIMARY KEY,
-  organizer_id bigint REFERENCES organizers(id),
-  name         text NOT NULL,
-  description  text,
-  address_line text,
-  city         text,
-  state        text,
-  country      text,
-  lat          numeric(10,6),
-  lng          numeric(10,6),
-  created_at   timestamptz NOT NULL DEFAULT now()
+-- FUNCIONES
+CREATE TABLE events.event_occurrences (
+  id        bigserial PRIMARY KEY,
+  event_id  bigint NOT NULL REFERENCES events.events(id) ON DELETE CASCADE,
+  venue_id  bigint NOT NULL REFERENCES events.venues(id),
+  starts_at timestamptz NOT NULL,
+  ends_at   timestamptz,
+  status    text NOT NULL DEFAULT 'scheduled',
+  slug      text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  UNIQUE (event_id, starts_at),
+  CONSTRAINT ck_occ_status CHECK (status IN ('scheduled','on_sale','closed','canceled'))
 );
 
--- venue_areas, venue_seats, seat_types, area_seat_type_rules,
--- ticket_types, event_occurrences, area_allocations, prices
--- (todos los de gestión de venue, fechas y pricing)
+-- ÁREAS y ASIENTOS por evento/función
+CREATE TABLE events.event_venue_areas (
+  id            bigserial PRIMARY KEY,
+  occurrence_id bigint NOT NULL REFERENCES events.event_occurrences(id) ON DELETE CASCADE,
+  name          text NOT NULL,
+  is_general_admission boolean NOT NULL DEFAULT false,
+  capacity      int,
+  position      int NOT NULL DEFAULT 0,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  deleted_at    timestamptz,
+  CONSTRAINT ck_event_venue_areas_ga_capacity CHECK (
+    (is_general_admission AND capacity IS NOT NULL)
+    OR (NOT is_general_admission AND capacity IS NULL)
+  )
+);
+
+CREATE TABLE events.event_venue_seats (
+  id                  bigserial PRIMARY KEY,
+  event_venue_area_id bigint NOT NULL REFERENCES events.event_venue_areas(id) ON DELETE CASCADE,
+  seat_label          text NOT NULL,
+  row_label           text,
+  number_label        text,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  updated_at          timestamptz NOT NULL DEFAULT now(),
+  deleted_at          timestamptz,
+  UNIQUE (event_venue_area_id, seat_label)
+);
+
+-- Tipos de asiento y tickets
+CREATE TABLE events.seat_types (
+  id          bigserial PRIMARY KEY,
+  code        text NOT NULL UNIQUE,
+  name        text NOT NULL,
+  description text,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  deleted_at  timestamptz
+);
+
+CREATE TABLE events.ticket_types (
+  id          bigserial PRIMARY KEY,
+  code        text NOT NULL UNIQUE,
+  name        text NOT NULL,
+  description text,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  deleted_at  timestamptz
+);
+
+-- Inventario GA por occurrence/área
+CREATE TABLE events.area_allocations (
+  id              bigserial PRIMARY KEY,
+  occurrence_id   bigint NOT NULL REFERENCES events.event_occurrences(id) ON DELETE CASCADE,
+  event_venue_area_id bigint NOT NULL REFERENCES events.event_venue_areas(id),
+  capacity        int NOT NULL,
+  sold            int NOT NULL DEFAULT 0,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  deleted_at      timestamptz,
+  UNIQUE (occurrence_id, event_venue_area_id),
+  CONSTRAINT ck_alloc_not_exceed CHECK (sold <= capacity)
+);
+
+-- Precios
+CREATE TABLE events.prices (
+  id             bigserial PRIMARY KEY,
+  occurrence_id  bigint NOT NULL REFERENCES events.event_occurrences(id) ON DELETE CASCADE,
+  ticket_type_id bigint NOT NULL REFERENCES events.ticket_types(id),
+  seat_type_id   bigint REFERENCES events.seat_types(id),
+  event_venue_area_id bigint REFERENCES events.event_venue_areas(id),
+  event_venue_seat_id bigint REFERENCES events.event_venue_seats(id),
+  amount_cents   bigint NOT NULL,
+  currency       text NOT NULL DEFAULT 'ARS',
+  starts_at      timestamptz,
+  ends_at        timestamptz,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  updated_at     timestamptz NOT NULL DEFAULT now(),
+  deleted_at     timestamptz,
+  CHECK (
+    (seat_type_id IS NOT NULL)::int +
+    (event_venue_area_id IS NOT NULL)::int +
+    (event_venue_seat_id IS NOT NULL)::int = 1
+  )
+);

--- a/backend/notification-service/src/main/resources/db/migration/V1__init.sql
+++ b/backend/notification-service/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,21 @@
+CREATE SCHEMA IF NOT EXISTS notifications;
+
+CREATE TABLE notifications.tickets_outbox (
+  id             bigserial PRIMARY KEY,
+  aggregate_type text NOT NULL,
+  aggregate_id   bigint NOT NULL,
+  event_type     text NOT NULL,
+  payload        jsonb NOT NULL,
+  occurred_at    timestamptz NOT NULL DEFAULT now(),
+  published_at   timestamptz
+);
+
+CREATE TABLE notifications.payments_outbox (
+  id             bigserial PRIMARY KEY,
+  aggregate_type text NOT NULL,
+  aggregate_id   bigint NOT NULL,
+  event_type     text NOT NULL,
+  payload        jsonb NOT NULL,
+  occurred_at    timestamptz NOT NULL DEFAULT now(),
+  published_at   timestamptz
+);

--- a/backend/order-service/src/main/resources/db/migration/V1__init.sql
+++ b/backend/order-service/src/main/resources/db/migration/V1__init.sql
@@ -1,45 +1,54 @@
-CREATE TABLE customers (
-  id          bigserial PRIMARY KEY,
-  email       text NOT NULL UNIQUE,
-  first_name  text,
-  last_name   text,
-  phone       text,
-  user_id     bigint,
-  created_at  timestamptz NOT NULL DEFAULT now()
+CREATE SCHEMA IF NOT EXISTS orders;
+
+CREATE TABLE orders.customers (
+  id        bigserial PRIMARY KEY,
+  email     text NOT NULL UNIQUE,
+  first_name text,
+  last_name  text,
+  phone      text,
+  user_id    bigint REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  UNIQUE (user_id) WHERE user_id IS NOT NULL
 );
 
-CREATE TABLE orders (
-  id            bigserial PRIMARY KEY,
-  customer_id   bigint NOT NULL,
-  organizer_id  bigint NOT NULL,
-  status        text NOT NULL DEFAULT 'pending',
-  total_cents   bigint NOT NULL DEFAULT 0,
-  currency      text NOT NULL DEFAULT 'ARS',
-  created_at    timestamptz NOT NULL DEFAULT now(),
-  paid_at       timestamptz
+CREATE TABLE orders.orders (
+  id           bigserial PRIMARY KEY,
+  customer_id  bigint NOT NULL REFERENCES orders.customers(id),
+  organizer_id bigint NOT NULL REFERENCES auth.organizers(id),
+  status       text NOT NULL DEFAULT 'pending',
+  total_cents  bigint NOT NULL DEFAULT 0,
+  currency     text NOT NULL DEFAULT 'ARS',
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+  deleted_at   timestamptz,
+  paid_at      timestamptz,
+  CONSTRAINT ck_orders_status CHECK (status IN ('pending','paid','failed','canceled','refunded','partially_refunded'))
 );
 
-ALTER TABLE orders
-  ADD CONSTRAINT ck_orders_status
-  CHECK (status IN ('pending','paid','failed','canceled','refunded','partially_refunded'));
-
-CREATE TABLE order_items (
-  id               bigserial PRIMARY KEY,
-  order_id         bigint NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
-  occurrence_id    bigint NOT NULL,
-  venue_area_id    bigint,
-  venue_seat_id    bigint,
-  ticket_type_id   bigint NOT NULL,
+CREATE TABLE orders.order_items (
+  id              bigserial PRIMARY KEY,
+  order_id        bigint NOT NULL REFERENCES orders.orders(id) ON DELETE CASCADE,
+  occurrence_id   bigint NOT NULL REFERENCES events.event_occurrences(id),
+  event_venue_area_id bigint REFERENCES events.event_venue_areas(id),
+  event_venue_seat_id bigint REFERENCES events.event_venue_seats(id),
+  ticket_type_id  bigint NOT NULL REFERENCES events.ticket_types(id),
   unit_price_cents bigint NOT NULL,
-  quantity         int NOT NULL DEFAULT 1
+  quantity         int NOT NULL DEFAULT 1,
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now(),
+  deleted_at       timestamptz,
+  UNIQUE (order_id, event_venue_seat_id),
+  CHECK ((event_venue_seat_id IS NULL) = (quantity > 0))
 );
 
-CREATE TABLE order_status_history (
+CREATE TABLE orders.order_status_history (
   id          bigserial PRIMARY KEY,
-  order_id    bigint NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+  order_id    bigint NOT NULL REFERENCES orders.orders(id) ON DELETE CASCADE,
   from_status text,
   to_status   text NOT NULL,
-  changed_by  bigint,
+  changed_by  bigint REFERENCES auth.users(id),
   changed_at  timestamptz NOT NULL DEFAULT now(),
   note        text
 );

--- a/backend/payment-service/src/main/resources/db/migration/V1__init.sql
+++ b/backend/payment-service/src/main/resources/db/migration/V1__init.sql
@@ -1,54 +1,67 @@
-CREATE TABLE payment_providers (
-  id   bigserial PRIMARY KEY,
-  code text NOT NULL UNIQUE,
-  name text NOT NULL
+CREATE SCHEMA IF NOT EXISTS payments;
+
+CREATE TABLE payments.payment_providers (
+  id          bigserial PRIMARY KEY,
+  code        text NOT NULL UNIQUE,
+  name        text NOT NULL,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  deleted_at  timestamptz
 );
 
-CREATE TABLE payment_intents (
-  id            bigserial PRIMARY KEY,
-  order_id      bigint NOT NULL,
-  provider_id   bigint NOT NULL REFERENCES payment_providers(id),
-  provider_ref  text,
-  status        text NOT NULL DEFAULT 'pending',
-  amount_cents  bigint NOT NULL,
-  currency      text NOT NULL DEFAULT 'ARS',
-  created_at    timestamptz NOT NULL DEFAULT now(),
-  updated_at    timestamptz NOT NULL DEFAULT now()
+CREATE TABLE payments.payment_intents (
+  id           bigserial PRIMARY KEY,
+  order_id     bigint NOT NULL REFERENCES orders.orders(id) ON DELETE CASCADE,
+  provider_id  bigint NOT NULL REFERENCES payments.payment_providers(id),
+  provider_ref text,
+  status       text NOT NULL DEFAULT 'pending',
+  amount_cents bigint NOT NULL,
+  currency     text NOT NULL DEFAULT 'ARS',
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+  deleted_at   timestamptz,
+  CONSTRAINT ck_pi_status CHECK (status IN ('pending','authorized','captured','failed','canceled'))
 );
 
-ALTER TABLE payment_intents
-  ADD CONSTRAINT ck_pi_status
-  CHECK (status IN ('pending','authorized','captured','failed','canceled'));
-
-CREATE TABLE payment_captures (
-  id                bigserial PRIMARY KEY,
-  payment_intent_id bigint NOT NULL REFERENCES payment_intents(id) ON DELETE CASCADE,
-  amount_cents      bigint NOT NULL,
-  captured_at       timestamptz NOT NULL DEFAULT now(),
+CREATE TABLE payments.payment_captures (
+  id                  bigserial PRIMARY KEY,
+  payment_intent_id   bigint NOT NULL REFERENCES payments.payment_intents(id) ON DELETE CASCADE,
+  amount_cents        bigint NOT NULL,
+  captured_at         timestamptz NOT NULL DEFAULT now(),
   provider_capture_ref text
 );
 
-CREATE TABLE refunds (
-  id                 bigserial PRIMARY KEY,
-  order_id           bigint NOT NULL,
-  payment_intent_id  bigint,
-  status             text NOT NULL DEFAULT 'requested',
-  reason             text,
-  amount_cents       bigint NOT NULL,
-  created_by         bigint,
-  created_at         timestamptz NOT NULL DEFAULT now(),
-  processed_at       timestamptz,
-  provider_ref       text
+CREATE TABLE payments.refunds (
+  id            bigserial PRIMARY KEY,
+  order_id      bigint NOT NULL REFERENCES orders.orders(id) ON DELETE CASCADE,
+  payment_intent_id bigint REFERENCES payments.payment_intents(id),
+  status        text NOT NULL DEFAULT 'requested',
+  reason        text,
+  amount_cents  bigint NOT NULL,
+  created_by    bigint REFERENCES auth.users(id),
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  deleted_at    timestamptz,
+  processed_at  timestamptz,
+  provider_ref  text,
+  CONSTRAINT ck_refunds_status CHECK (status IN ('requested','processing','succeeded','failed'))
 );
 
-ALTER TABLE refunds
-  ADD CONSTRAINT ck_refunds_status
-  CHECK (status IN ('requested','processing','succeeded','failed'));
-
-CREATE TABLE refund_items (
+CREATE TABLE payments.refund_items (
   id            bigserial PRIMARY KEY,
-  refund_id     bigint NOT NULL REFERENCES refunds(id) ON DELETE CASCADE,
-  order_item_id bigint NOT NULL,
-  ticket_id     bigint,
+  refund_id     bigint NOT NULL REFERENCES payments.refunds(id) ON DELETE CASCADE,
+  order_item_id bigint NOT NULL REFERENCES orders.order_items(id) ON DELETE CASCADE,
+  ticket_id     bigint REFERENCES tickets.tickets(id),
   amount_cents  bigint NOT NULL
+);
+
+CREATE TABLE payments.refund_policies (
+  id           bigserial PRIMARY KEY,
+  organizer_id bigint REFERENCES auth.organizers(id) ON DELETE CASCADE,
+  event_id     bigint REFERENCES events.events(id) ON DELETE CASCADE,
+  policy_json  jsonb NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+  deleted_at   timestamptz,
+  UNIQUE (organizer_id, event_id)
 );

--- a/backend/ticket-service/src/main/resources/db/migration/V1__init.sql
+++ b/backend/ticket-service/src/main/resources/db/migration/V1__init.sql
@@ -1,41 +1,43 @@
-CREATE TABLE tickets (
-  id               bigserial PRIMARY KEY,
-  order_item_id    bigint NOT NULL,
-  occurrence_id    bigint NOT NULL,
-  venue_area_id    bigint,
-  venue_seat_id    bigint,
-  ticket_type_id   bigint NOT NULL,
-  code             text NOT NULL UNIQUE,
-  status           text NOT NULL DEFAULT 'issued',
-  issued_at        timestamptz NOT NULL DEFAULT now(),
-  checked_in_at    timestamptz
+CREATE SCHEMA IF NOT EXISTS tickets;
+
+CREATE TABLE tickets.tickets (
+  id             bigserial PRIMARY KEY,
+  order_item_id  bigint NOT NULL REFERENCES orders.order_items(id) ON DELETE CASCADE,
+  occurrence_id  bigint NOT NULL REFERENCES events.event_occurrences(id),
+  event_venue_area_id bigint REFERENCES events.event_venue_areas(id),
+  event_venue_seat_id bigint REFERENCES events.event_venue_seats(id),
+  ticket_type_id bigint NOT NULL REFERENCES events.ticket_types(id),
+  code           text NOT NULL UNIQUE,
+  status         text NOT NULL DEFAULT 'issued',
+  issued_at      timestamptz NOT NULL DEFAULT now(),
+  checked_in_at  timestamptz,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  updated_at     timestamptz NOT NULL DEFAULT now(),
+  deleted_at     timestamptz,
+  CONSTRAINT ck_tickets_status CHECK (status IN ('issued','checked_in','canceled','refunded'))
 );
 
-ALTER TABLE tickets
-  ADD CONSTRAINT ck_tickets_status
-  CHECK (status IN ('issued','checked_in','canceled','refunded'));
-
-CREATE TABLE ticket_status_history (
-  id           bigserial PRIMARY KEY,
-  ticket_id    bigint NOT NULL REFERENCES tickets(id) ON DELETE CASCADE,
-  from_status  text,
-  to_status    text NOT NULL,
-  changed_by   bigint,
-  changed_at   timestamptz NOT NULL DEFAULT now(),
-  note         text
+CREATE TABLE tickets.ticket_status_history (
+  id          bigserial PRIMARY KEY,
+  ticket_id   bigint NOT NULL REFERENCES tickets.tickets(id) ON DELETE CASCADE,
+  from_status text,
+  to_status   text NOT NULL,
+  changed_by  bigint REFERENCES auth.users(id),
+  changed_at  timestamptz NOT NULL DEFAULT now(),
+  note        text
 );
 
-CREATE TABLE holds (
+CREATE TABLE tickets.holds (
   id            bigserial PRIMARY KEY,
-  customer_id   bigint,
-  occurrence_id bigint NOT NULL,
-  venue_area_id bigint,
-  venue_seat_id bigint,
+  customer_id   bigint REFERENCES orders.customers(id),
+  occurrence_id bigint NOT NULL REFERENCES events.event_occurrences(id),
+  event_venue_area_id bigint REFERENCES events.event_venue_areas(id),
+  event_venue_seat_id bigint REFERENCES events.event_venue_seats(id),
   quantity      int NOT NULL DEFAULT 1,
   expires_at    timestamptz NOT NULL,
-  status        text NOT NULL DEFAULT 'active'
+  status        text NOT NULL DEFAULT 'active',
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  deleted_at    timestamptz,
+  CONSTRAINT ck_holds_status CHECK (status IN ('active','converted','expired','canceled'))
 );
-
-CREATE UNIQUE INDEX uq_holds_seat_active
-  ON holds(occurrence_id, venue_seat_id)
-  WHERE venue_seat_id IS NOT NULL AND status = 'active';

--- a/docs/README_DataBase.md
+++ b/docs/README_DataBase.md
@@ -1,0 +1,119 @@
+# Ticketera Database Documentation
+
+## Overview
+La base de datos de **Ticketera** está organizada en **6 schemas**:
+
+- `auth`: Usuarios, roles, organizadores, membresías y claves API.
+- `events`: Eventos, funciones (occurrences), venues, áreas y precios.
+- `orders`: Clientes, órdenes y sus ítems.
+- `tickets`: Tickets emitidos, historial y reservas temporales (holds).
+- `payments`: Métodos de pago, intents, capturas y reembolsos.
+- `notifications`: Tablas outbox para publicación de eventos.
+
+---
+
+## Timestamps y Soft Delete
+Todas las entidades principales incluyen:
+- `created_at`: fecha de creación.
+- `updated_at`: actualizado automáticamente con triggers.
+- `deleted_at`: soft delete (NULL = activo, NOT NULL = borrado lógico).
+
+Las tablas históricas (`*_history`) y `outbox` **no incluyen deleted_at** ya que son inmutables.
+
+---
+
+## Schemas
+
+### 1. Auth
+- **users**: credenciales y datos de usuarios del sistema.
+- **roles**: roles predefinidos (`admin`, `manager`, `seller`, etc.).
+- **organizers**: organizadores de eventos.
+- **categories**: categorías de eventos.
+- **organizer_memberships**: qué usuarios pertenecen a qué organizador y con qué rol.
+- **api_keys**: claves para apps externas (POS, check-in apps).
+
+### 2. Events
+- **events**: un evento base (ej. "Lollapalooza 2025").
+- **event_occurrences**: cada función/fecha del evento (ej. "Día 1 - 10/03/2025").
+- **venues**: lugares físicos (ej. "Estadio River").
+- **event_venue_areas**: áreas de un venue adaptadas a una occurrence (ej. "Campo VIP" solo en ese show).
+- **event_venue_seats**: butacas concretas por occurrence (para plateas numeradas).
+- **seat_types**: clasificaciones de asientos (VIP, platea, campo).
+- **ticket_types**: tipos de ticket (adulto, niño, promo).
+- **event_media**: imágenes asociadas al evento.
+- **event_grants**: permisos granulares para miembros sobre eventos.
+- **area_allocations**: cupo disponible por área y función.
+- **prices**: precio por combinación de occurrence + área/asiento/tipo.
+
+### 3. Orders
+- **customers**: clientes compradores.
+- **orders**: órdenes generadas por clientes.
+- **order_items**: tickets o asientos dentro de una orden.
+- **order_status_history**: historial de cambios de estado en la orden.
+
+### 4. Tickets
+- **tickets**: tickets emitidos con código único (QR/UUID).
+- **ticket_status_history**: historial de cambios de estado.
+- **holds**: reservas temporales para prevenir sobreventa.
+
+### 5. Payments
+- **payment_providers**: métodos de pago soportados (ej. MercadoPago, Stripe).
+- **payment_intents**: intención de pago creada para una orden.
+- **payment_captures**: confirmación de captura de dinero.
+- **refunds**: solicitudes de devolución.
+- **refund_items**: detalle de qué ítems/tickets fueron reembolsados.
+- **refund_policies**: políticas de reembolso por organizador/evento.
+
+### 6. Notifications (Outbox)
+- **tickets_outbox**: eventos relacionados con tickets y órdenes (ej. `TicketIssued`, `OrderCreated`).
+- **payments_outbox**: eventos relacionados con pagos (`PaymentSucceeded`, `RefundProcessed`).
+
+Estas tablas implementan el **Transactional Outbox Pattern**:
+- Los cambios de dominio y la escritura del evento ocurren en la misma transacción.
+- Los eventos pendientes (`published_at IS NULL`) son procesados por un worker y publicados en RabbitMQ/Kafka.
+- Una vez publicados, se marca `published_at` para evitar duplicados.
+
+---
+
+## Relaciones principales
+
+- `auth.users` ↔ `orders.customers` (un usuario puede ser cliente).
+- `auth.organizers` ↔ `events.events` (un organizador crea eventos).
+- `events.events` ↔ `events.event_occurrences` (un evento puede tener múltiples funciones).
+- `events.event_occurrences` ↔ `events.event_venue_areas` (las áreas del venue se definen por función).
+- `orders.orders` ↔ `orders.order_items` ↔ `tickets.tickets`.
+- `orders.orders` ↔ `payments.payment_intents` ↔ `payments.payment_captures`.
+- `orders.orders` ↔ `payments.refunds`.
+
+---
+
+## Restricciones y Checks
+
+- Estados (`status`) tienen `CHECK` constraints en `events.events`, `orders.orders`, `tickets.tickets`, `payments.payment_intents`, `payments.refunds`.
+- `area_allocations.sold <= capacity` asegura no sobrepasar cupo.
+- `tickets` asegura unicidad de `code`.
+- `holds` asegura que no existan reservas activas duplicadas para un mismo asiento.
+- Soft delete implementado en todas las entidades principales.
+
+---
+
+## Triggers
+- **`updated_at`**: cada tabla principal tiene un trigger `BEFORE UPDATE` que setea automáticamente `updated_at = now()`.  
+- Opcional: podrían añadirse triggers de auditoría para registrar cambios en logs.
+
+---
+
+# Ejemplo de Flujo
+
+1. Cliente compra un ticket:  
+   - Se crea `orders.orders` y `orders.order_items`.  
+   - Se generan `tickets.tickets` asociados.  
+   - Se crea `payments.payment_intents`.  
+   - En la misma transacción se inserta un registro en `payments_outbox` (`PaymentRequested`).  
+
+2. Worker publica en Kafka:  
+   - Lee `payments_outbox` donde `published_at IS NULL`.  
+   - Publica el evento.  
+   - Actualiza `published_at`.  
+
+---


### PR DESCRIPTION
- Added created_at, updated_at, deleted_at to all domain entities
- Implemented triggers to auto-update updated_at
- Refactored venue model: introduced event_venue_areas and event_venue_seats linked to event_occurrences for per-event configuration
- Normalized relations across auth, events, orders, tickets, payments schemas
- Preserved immutability in history and outbox tables (no soft delete)
- Consolidated schema for Flyway migrations (auth, events, orders, tickets, payments, notifications)